### PR TITLE
Add Rust Tak recursion benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The following table shows which languages include implementations of each algori
 | php | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | python | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | ruby | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| rust | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ |
+| rust | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
 | swift | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ |
 | zig | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ |
 

--- a/langs/rust/benchmark.yml
+++ b/langs/rust/benchmark.yml
@@ -13,4 +13,6 @@ strategy:
       - collatz/MaxSequence
 
       - mandelbrot/Simple
+      - recursion/Tak
+
       - linpack/Linpack

--- a/langs/rust/recursion/Tak.rs
+++ b/langs/rust/recursion/Tak.rs
@@ -1,0 +1,17 @@
+fn tak(x: i32, y: i32, z: i32) -> i32 {
+    if y < x {
+        return tak(tak(x - 1, y, z), tak(y - 1, z, x), tak(z - 1, x, y));
+    } else {
+        return z;
+    }
+}
+
+fn main() {
+    let start = std::time::Instant::now();
+
+    let result = tak(30, 22, 12);
+    println!("{}", result);
+
+    let elapsed = start.elapsed();
+    println!("Execution time: {}ms", elapsed.as_millis());
+}


### PR DESCRIPTION
## Summary
- implement Tak benchmark for Rust
- enable recursion/Tak in Rust benchmark config
- document new Rust benchmark in README

## Testing
- `make -C langs/rust`
- `python3 benchmark.py run --lang rust --output markdown=/tmp/res.md`

------
https://chatgpt.com/codex/tasks/task_e_683fedec9da8832899619936b4bba7d7