### PR TITLE
Feature: Add Tak benchmark in C

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The following table shows which languages include implementations of each algori
 
 | Language | collatz/MaxSequence | linpack/Linpack | mandelbrot/Simple | primes/Atkin | primes/Simple | recursion/Tak | treap/Naive |
 |---|---|---|---|---|---|---|---|
-| c | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ |
+| c | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ |
 | c-plus-plus | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | c-sharp | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | fortran | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ |

--- a/langs/c/benchmark.yml
+++ b/langs/c/benchmark.yml
@@ -10,5 +10,4 @@ strategy:
 
     files:
       - primes/Simple
-      - primes/Atkin
       - recursion/Tak

--- a/langs/c/recursion/Tak.c
+++ b/langs/c/recursion/Tak.c
@@ -23,7 +23,7 @@ int main() {
     end_time = clock();
     duration = ((double)(end_time - start_time)) / CLOCKS_PER_SEC * 1000.0;
 
-    printf("Execution time: %.2f ms\n", duration);
+    printf("Execution time: %.2fms\n", duration);
 
     return 0;
 }


### PR DESCRIPTION
## Summary

Implements `recursion/Tak` benchmark in `C`.

<!-- Brief description of implementation approach -->

## Checklist

Please review [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed guidelines.

- [ ] Studied reference implementations (PHP, C++, or Python)
- [ ] Implementation uses exact same logic as references (no optimizations)
- [ ] File placed in correct directory: `langs/<language>/<algorithm>/<Name>.<ext>`
- [ ] Added to `benchmark.yml` in language directory
- [ ] README.md implementation table updated (❌ → ✅)
- [ ] Tested locally with Docker
- [ ] Commit follows format: `feat(<language>): add <algorithm>/<Name> benchmark`

## Verification

<!-- How did you verify the implementation matches references? -->

Example:
- Compared loop structures with `langs/php/primes/Simple.php`
- Verified same array operations as C++ reference
- Tested output matches expected results

## Notes

<!-- Any additional context or issues encountered -->


<details>
<summary>Original Description</summary>

**Description**
Add the recursion benchmark in C
Update C benchmarks under langs/c/benchmark.yml

Output: 
13
Execution time: 93.54 ms


=== Code Execution Successful ===

</details>